### PR TITLE
Tiny changes to ensure service works with corresponding helm chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,6 @@ COPY src /app/src
 RUN pip3 install .
 COPY app.py /app
 
+EXPOSE 8000
 ENTRYPOINT ["/bin/sh", "-c"]
-CMD ["uvicorn app:app --host 0.0.0.0 --port 8080"]
+CMD ["uvicorn app:app --host 0.0.0.0 --port 8000"]

--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ class GenerateLatentsResponse(BaseModel):
     error: str = None
 
 
+logging.basicConfig(level=logging.INFO)
 logger = getLogger("app")
 
 
@@ -104,5 +105,4 @@ def generate_latents(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
- Run service on port 8000 consistently (update container image)
- Add INFO logging, even when launched via uvicorn CLI, for clarity as we work on deployment